### PR TITLE
PHP 7 Fatal Er: Call to undefined function split()

### DIFF
--- a/PHP/airplay.php
+++ b/PHP/airplay.php
@@ -122,7 +122,7 @@ if (PHP_SAPI === 'cli') {
 		usage();
 		exit(1);
 	} else {
-		$host =  split(':',$host);
+		$host = explode(':',$host);
 		if (count($host) > 1) {
 			$airplay = new AirPlay($host[0],$host[1]);
 		} else {


### PR DESCRIPTION
```
MacOS Catalina v10.15.4

PHP 7.3.11 (cli) (built: Feb 29 2020 02:50:36) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.11, Copyright (c) 1998-2018 Zend Technologies
```